### PR TITLE
don't copy name

### DIFF
--- a/service_call.c
+++ b/service_call.c
@@ -32,6 +32,7 @@ size_t service_call_process(const uint8_t *buffer, size_t buffer_size,
     for (i = 0; i < callbacks_len; ++i) {
         if (!strncmp(method_name, callbacks[i].name, method_name_len)) {
             callbacks[i].cb(argc, &cmp, &out_cmp);
+            break;
         }
     }
 


### PR DESCRIPTION
- doesn't allocate on stack
- no limit on name length
- no copying needed