### PR TITLE
Pass arguments as a list

### DIFF
--- a/python/service_call.py
+++ b/python/service_call.py
@@ -18,7 +18,7 @@ def encode_call(method_name, params):
     """
     Encode a call to the given method with the given parameters.
     """
-    data = msgpack.packb(method_name) + msgpack.packb(params)
+    data = msgpack.packb([method_name] + params)
     return serial_datagrams.datagram_encode(data)
 
 def decode_call(data):
@@ -31,7 +31,10 @@ def decode_call(data):
     u = msgpack.Unpacker(encoding='ascii')
     u.feed(data)
 
-    return tuple(u)
+    command = next(u)
+
+    return  command[0], command[1:]
+
 
 def handle_connection(handlers, socket):
     """
@@ -45,11 +48,13 @@ def handle_connection(handlers, socket):
     if retval is not None:
         socket.send(msgpack.packb(retval))
 
-def call(adress, method_name, method_args={}):
+def call(adress, method_name, method_args=None):
     """
     Calls the given method on the given adress (a tuple containing hostname and port),
     With the given parameters (dict object).
     """
+    if method_args is None:
+        method_args = []
     connection = socket.create_connection(adress)
     data = encode_call(method_name, method_args)
     connection.sendall(data)

--- a/python/setup.py
+++ b/python/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 args = dict(
     name='cvra_rpc',
-    version='0.1',
+    version='0.2',
     description='Simple RPC protocol for CVRA robots',
     packages=['.'],
     install_requires=['msgpack-python'],

--- a/service_call.c
+++ b/service_call.c
@@ -4,8 +4,8 @@
 void service_call_encode(cmp_ctx_t *cmp, cmp_mem_access_t *mem, uint8_t *buffer, size_t buffer_size, const char *method_name, int param_count)
 {
     cmp_mem_access_init(cmp, mem, buffer, buffer_size);
+    cmp_write_array(cmp, param_count + 1);
     cmp_write_str(cmp, method_name, strlen(method_name));
-    cmp_write_map(cmp, param_count);
 }
 
 size_t service_call_process(const uint8_t *buffer, size_t buffer_size,
@@ -23,11 +23,15 @@ size_t service_call_process(const uint8_t *buffer, size_t buffer_size,
 
     cmp_mem_access_init(&out_cmp, &out_mem, output_buffer, output_buffer_size);
 
+    cmp_read_array(&cmp, &argc);
+
+    /* Remove method name from argc */
+    argc -= 1;
+
     cmp_read_str_size(&cmp, &method_name_len);
     size_t name_pos = cmp_mem_access_get_pos(&mem);
     cmp_mem_access_set_pos(&mem, name_pos + method_name_len); // jump name string
     method_name = cmp_mem_access_get_ptr_at_pos(&mem, name_pos);
-    cmp_read_map(&cmp, &argc);
 
     for (i = 0; i < callbacks_len; ++i) {
         if (!strncmp(method_name, callbacks[i].name, method_name_len)) {


### PR DESCRIPTION
This fixes both points raised in #3 .

cc @Stapelzeiger 