### PR TITLE
Ignores unknown messages

### DIFF
--- a/python/cvra_rpc/message.py
+++ b/python/cvra_rpc/message.py
@@ -51,6 +51,7 @@ def send(target, name, args=None):
     sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     data = encode(name, args)
     sock.sendto(data, target)
+    sock.close()
 
 
 def handle_message(data, callbacks):

--- a/python/cvra_rpc/message.py
+++ b/python/cvra_rpc/message.py
@@ -59,4 +59,5 @@ def handle_message(data, callbacks):
     Handles a single datagram and calls the correct callback.
     """
     name, args = decode(data)
-    callbacks[name](args)
+    if name in callbacks:
+        callbacks[name](args)

--- a/python/test/test_messages.py
+++ b/python/test/test_messages.py
@@ -66,6 +66,14 @@ class MessageRequestHandlerTestCase(unittest.TestCase):
         message.handle_message(data, callbacks)
         callbacks['bar'].assert_any_call([])
 
+    def test_unknown_callbacks_are_ignored(self):
+        """
+        Checks that unkown callbacks are silently ignored.
+        """
+        callbacks = {'foo': Mock()}
+        data = message.encode('bar')
+        message.handle_message(data, callbacks)
+
     def test_args_forwarded(self):
         callbacks = {'foo': Mock()}
         data = message.encode('foo', [1, 2, 3])

--- a/python/test/test_messages.py
+++ b/python/test/test_messages.py
@@ -5,7 +5,7 @@ import socketserver
 
 import unittest
 try:
-    from unittest.mock import Mock
+    from unittest.mock import Mock, patch
 except ImportError:
     from mock import Mock
 
@@ -43,6 +43,14 @@ class MessageDecodingTestCase(unittest.TestCase):
 
         self.assertEqual('foo', name)
         self.assertEqual([1, 2, 3], args)
+
+
+class MessageSendTestCase(unittest.TestCase):
+    @patch('socket.socket')
+    def test_socket_is_closed(self, socket):
+        socket.return_value = Mock()
+        message.send(('localhost', 1234), 'foo', [1, 2, 3])
+        socket.return_value.close.assert_any_call()
 
 
 class MessageRequestHandlerTestCase(unittest.TestCase):


### PR DESCRIPTION
For now this patch drops all unknown messages. Maybe logging them would be better ?

Also I don't know what to do for unknown service calls. Maybe crashing hard is best.