### PR TITLE
Encode floats as single precision

### DIFF
--- a/python/cvra_rpc/message.py
+++ b/python/cvra_rpc/message.py
@@ -13,7 +13,7 @@ def encode(message_name, args=None):
     if args is None:
         args = []
 
-    return msgpack.packb([message_name] + args)
+    return msgpack.packb([message_name] + args, use_single_float=True)
 
 
 def decode(data):

--- a/python/cvra_rpc/service_call.py
+++ b/python/cvra_rpc/service_call.py
@@ -22,7 +22,7 @@ def encode_call(method_name, params):
     """
     Encode a call to the given method with the given parameters.
     """
-    data = msgpack.packb([method_name] + params)
+    data = msgpack.packb([method_name] + params, use_single_float=True)
     return serial_datagram.encode(data)
 
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 args = dict(
     name='cvra_rpc',
-    version='0.4',
+    version='0.5',
     description='Simple RPC protocol for CVRA robots',
     packages=['cvra_rpc'],
     install_requires=['msgpack-python'],

--- a/python/test/test_messages.py
+++ b/python/test/test_messages.py
@@ -35,6 +35,13 @@ class MessageEncodingTestCase(unittest.TestCase):
         data = message.encode("foo", [1, 2, 3])
         self.assertEqual(msgpack_decode(data), ['foo', 1, 2, 3])
 
+    def test_encoding_float_single_precision(self):
+        """
+        Checks that we can encode float as single precision.
+        """
+        data = message.encode("foo", [1.])
+        self.assertEqual(data[1 + 3 + 1], 0xca)
+
 
 class MessageDecodingTestCase(unittest.TestCase):
     def test_decoding_message(self):

--- a/python/test/test_service_call.py
+++ b/python/test/test_service_call.py
@@ -24,6 +24,16 @@ class ServiceCallEncodingTestCase(unittest.TestCase):
 
         self.assertEqual(command, ['foo', 1, 2, 3])
 
+    def test_float_single_precision(self):
+        """
+        Checks that floats are single precision.
+        """
+        data = service_call.encode_call("foo", [1.])
+        data = serial_datagram.decode(data)
+
+        # Check that we have the marker for single precision float
+        self.assertEqual(data[1 + 3 + 1], 0xca)
+
     def test_decoding_method(self):
         """
         Checks that we can decode a method.


### PR DESCRIPTION
This makes interop with C easier, since Python's "floats" will map to C's floats.